### PR TITLE
Fix udp sending on network change

### DIFF
--- a/app/src/main/java/pl/mrwojtek/sensrec/app/Records.java
+++ b/app/src/main/java/pl/mrwojtek/sensrec/app/Records.java
@@ -352,6 +352,9 @@ public class Records extends Fragment {
 
         @Override
         public synchronized void onEvent(int event, String path) {
+            if (path == null) {
+                return;
+            }
             if (path.equals(tabuPath)) {
                 return;
             }

--- a/lib/src/main/java/pl/mrwojtek/sensrec/StepReadWriteStream.java
+++ b/lib/src/main/java/pl/mrwojtek/sensrec/StepReadWriteStream.java
@@ -160,6 +160,9 @@ public class StepReadWriteStream extends OutputStream {
 
     public int writeTo(WritableByteChannel byteChannel, int bytes) throws IOException {
         int readCount;
+        if (byteChannel == null) {
+            return 0;
+        }
         synchronized (content) {
             readCount = Math.min(count, bytes);
         }


### PR DESCRIPTION
This pull requests fixes sens-rec behaviour when streaming via udp and losing network connectivity.

* Exceptions working on closed sockets are avoided
* Reconnect timers are calculated
* Connection errors in recordStart are now taken into consideration